### PR TITLE
chore: automate version tagging and fix gofmt check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Generate coverage report
+      if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.24.x'
+      shell: bash
       run: go tool cover -html=coverage.out -o coverage.html
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,10 @@ jobs:
     - name: Run go fmt check
       shell: bash
       run: |
-        if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
+        fmt_output=$(gofmt -s -l $(git ls-files '*.go'))
+        if [ -n "$fmt_output" ]; then
           echo "Code is not formatted:"
-          gofmt -s -l .
+          echo "$fmt_output"
           exit 1
         fi
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
           type=raw,value=latest,enable={{is_default_branch}}
-          type=sha,prefix={{branch}}-
+          type=sha
 
     - name: Get version info
       id: version

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,53 @@
+name: Bump Version
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  bump:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Get last tag
+        id: last
+        run: |
+          tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+
+      - name: Calculate next version
+        id: next
+        run: |
+          last=${{ steps.last.outputs.tag }}
+          version=${last#v}
+          IFS='.' read -r major minor patch <<<"$version"
+          labels=$(jq -r '.pull_request.labels | map(.name) | join(" ")' "$GITHUB_EVENT_PATH")
+          if echo "$labels" | grep -qi "hotfix"; then
+            patch=$((patch+1))
+          else
+            minor=$((minor+1))
+            patch=0
+          fi
+          echo "version=v${major}.${minor}.${patch}" >> $GITHUB_OUTPUT
+
+      - name: Create tag
+        env:
+          NEW_TAG: ${{ steps.next.outputs.version }}
+        run: |
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"

--- a/internal/domain/cloning/job.go
+++ b/internal/domain/cloning/job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/italoag/ghcloner/internal/domain/repository"
@@ -103,7 +104,7 @@ func NewCloneJob(
 // GetDestinationPath returns the full path where the repository will be cloned
 func (cj *CloneJob) GetDestinationPath() string {
 	if cj.Options.CreateOrgDirs {
-		return fmt.Sprintf("%s/%s/%s", cj.BaseDirectory, cj.Repository.Owner, cj.Repository.Name)
+		return filepath.Join(cj.BaseDirectory, cj.Repository.Owner, cj.Repository.Name)
 	}
 	return cj.Repository.GetLocalPath(cj.BaseDirectory)
 }

--- a/internal/domain/cloning/job_test.go
+++ b/internal/domain/cloning/job_test.go
@@ -1,6 +1,7 @@
 package cloning
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -31,19 +32,16 @@ func TestCloneJob_GetDestinationPath(t *testing.T) {
 		name      string
 		baseDir   string
 		createOrg bool
-		expected  string
 	}{
 		{
 			name:      "simple path",
 			baseDir:   "/tmp",
 			createOrg: false,
-			expected:  "/tmp/test-repo",
 		},
 		{
 			name:      "org directory structure",
 			baseDir:   "/tmp",
 			createOrg: true,
-			expected:  "/tmp/test-owner/test-repo",
 		},
 	}
 
@@ -53,7 +51,11 @@ func TestCloneJob_GetDestinationPath(t *testing.T) {
 			options.CreateOrgDirs = tt.createOrg
 
 			job := NewCloneJob(repo, tt.baseDir, options)
-			assert.Equal(t, tt.expected, job.GetDestinationPath())
+			expected := filepath.Join(tt.baseDir, repo.Name)
+			if tt.createOrg {
+				expected = filepath.Join(tt.baseDir, repo.Owner, repo.Name)
+			}
+			assert.Equal(t, expected, job.GetDestinationPath())
 		})
 	}
 }

--- a/internal/domain/repository/entity_test.go
+++ b/internal/domain/repository/entity_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -173,29 +174,26 @@ func TestRepository_GetLocalPath(t *testing.T) {
 	tests := []struct {
 		name    string
 		baseDir string
-		want    string
 	}{
 		{
 			name:    "simple path",
 			baseDir: "/tmp",
-			want:    "/tmp/test-repo",
 		},
 		{
 			name:    "path with trailing slash",
 			baseDir: "/tmp/",
-			want:    "/tmp/test-repo",
 		},
 		{
 			name:    "nested path",
 			baseDir: "/home/user/projects",
-			want:    "/home/user/projects/test-repo",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := repo.GetLocalPath(tt.baseDir)
-			assert.Equal(t, tt.want, got)
+			want := filepath.Join(tt.baseDir, repo.Name)
+			assert.Equal(t, want, got)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- adjust gofmt check to avoid Windows build failures
- add workflow to tag new versions based on PR labels

## Testing
- `gofmt -s -l $(git ls-files '*.go')`
- `go test ./internal/... -count=1`
- `go test ./test/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b4e7df48388331a7037646eec60e62